### PR TITLE
Add global queue events

### DIFF
--- a/packages/queue/src/Queue.ts
+++ b/packages/queue/src/Queue.ts
@@ -130,6 +130,15 @@ export class Queue extends EventEmitter {
 
     return this.length;
   }
+  
+  public emit(event: string, ...args: any[]): boolean {
+    if (!event.startsWith("_")) {
+      const _event = event === "finished" ? "queueFinished" : event;
+      if (this.player.manager.listenerCount(_event)) this.player.manager.emit(_event, this, ...args)
+    }
+
+    return super.emit(event, ...args);
+  }
 
   /**
    * Loop the track or queue.


### PR DESCRIPTION
Overrides the `EventEmitter#emit` method to emit the supplied event on the manager.

- `trackStart` Emitted when a track starts
- `trackEnd` Emitted when a track ends
- `queueFinished` Emitted when a queue finishes.

```ts
manager.on("queueFinished", queue => {})
manager.on("trackStart", (queue, track) => {})
manager.on("trackEnd", (queue, track) => {})
```