### PR TITLE
🔀 fix shuffle algorithm

### DIFF
--- a/packages/queue/src/Queue.ts
+++ b/packages/queue/src/Queue.ts
@@ -151,7 +151,7 @@ export class Queue extends TypedEmitter<QueueEvents> {
     }
 
     shuffle(): void {
-        for (let i = this.tracks.length; i > 0; i--) {
+        for (let i = this.tracks.length - 1; i > 0; i--) {
             const j = Math.floor(Math.random() * (i + 1));
             [this.tracks[i], this.tracks[j]] = [this.tracks[j], this.tracks[i]];
         }


### PR DESCRIPTION
Starting point should be the array length minus 1, otherwise in some cases it pushes undefined to the tracks array